### PR TITLE
Compatibility with Ubuntu 22.04 and ROS2

### DIFF
--- a/include/pandarSwiftDriver.h
+++ b/include/pandarSwiftDriver.h
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <input.h>
+#include <boost/function.hpp>
 
 #define PANDAR128_READ_PACKET_SIZE (1800)
 #define PANDARQT128_READ_PACKET_SIZE (200)

--- a/include/pandarSwiftSDK.h
+++ b/include/pandarSwiftSDK.h
@@ -425,6 +425,7 @@ class PandarSwiftSDK {
 	int processLiDARData();
 	void publishPointsThread();
   void stop();
+  void standBy(bool standBy);
 
  private:
 

--- a/src/laser_ts.cpp
+++ b/src/laser_ts.cpp
@@ -17,6 +17,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#include <string>
 #include <vector>
 #include "laser_ts.h"
 #include <fstream>

--- a/src/pandarSwiftSDK.cc
+++ b/src/pandarSwiftSDK.cc
@@ -9,6 +9,7 @@
  *   This class PandarSwiftSDKs raw Pandar128 3D LIDAR packets to PointCloud2.
  */
 #include "pandarSwiftSDK.h"
+#include <boost/algorithm/string.hpp>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>

--- a/src/pandarSwiftSDK.cc
+++ b/src/pandarSwiftSDK.cc
@@ -498,6 +498,11 @@ void PandarSwiftSDK::stop() {
 	return;
 }
 
+void PandarSwiftSDK::standBy(bool standBy)
+{
+	auto err = (standBy == true) ? TcpCommandSetLidarStandbyMode(m_pTcpCommandClient) : TcpCommandSetLidarNormalMode(m_pTcpCommandClient);
+}
+
 int PandarSwiftSDK::parseData(Pandar128PacketVersion13 &packet, const uint8_t *recvbuf, const int len) {
 	int index = 0;
 	if(recvbuf[0] != 0xEE && recvbuf[1] != 0xFF && recvbuf[2] != 1 ) {    


### PR DESCRIPTION
## Description
This pull request introduces modifications to improve compatibility with Ubuntu 22.04. Ubuntu 22.04 ships with default versions of certain tools and libraries that are different from the ones expected by the original configuration. The versions of the primary elements affected were:
- GCC compiler version: 11.3.0
- libboost-dev version: 1.74.0

The version discrepancy led to build errors in the repository, hence, these changes were implemented to rectify them.

## Testing and Validation
The modifications have been tested on both Ubuntu 20.04 and Ubuntu 22.04 to ensure continued compatibility across these platforms.